### PR TITLE
fix: update icon imports to use individual icon paths for better tree-shaking

### DIFF
--- a/src/components/accordion.svelte
+++ b/src/components/accordion.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { ChevronDown, Icon as IconType } from '@lucide/svelte';
+  import { Icon as IconType } from '@lucide/svelte';
+  import ChevronDown from '@lucide/svelte/icons/chevron-down';
 
   import { cn } from '$util/cn';
   import SmallTitle from './small-title.svelte';

--- a/src/components/carousel.svelte
+++ b/src/components/carousel.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-  import { ChevronLeft, ChevronRight } from '@lucide/svelte';
   import { type EmblaCarouselType, type EmblaOptionsType } from 'embla-carousel';
   import AutoHeight from 'embla-carousel-auto-height';
+  import ChevronLeft from '@lucide/svelte/icons/chevron-left';
+  import ChevronRight from '@lucide/svelte/icons/chevron-right';
   import emblaCarouselSvelte from 'embla-carousel-svelte';
 
   import { carousels } from '$store/services';

--- a/src/components/content/contact.svelte
+++ b/src/components/content/contact.svelte
@@ -1,18 +1,16 @@
 <script lang="ts">
-  import {
-    BadgeAlert,
-    BadgeCheck,
-    Clock,
-    ListTree,
-    Mail,
-    MessageCircleMore,
-    Phone,
-    SendHorizonal,
-    ShieldCheck,
-    User
-  } from '@lucide/svelte';
-  import type { SubmitFunction } from '@sveltejs/kit';
   import { enhance } from '$app/forms';
+  import BadgeAlert from '@lucide/svelte/icons/badge-alert';
+  import BadgeCheck from '@lucide/svelte/icons/badge-check';
+  import Clock from '@lucide/svelte/icons/clock';
+  import ListTree from '@lucide/svelte/icons/list-tree';
+  import Mail from '@lucide/svelte/icons/mail';
+  import MessageCircleMore from '@lucide/svelte/icons/message-circle-more';
+  import Phone from '@lucide/svelte/icons/phone';
+  import SendHorizonal from '@lucide/svelte/icons/send-horizonal';
+  import ShieldCheck from '@lucide/svelte/icons/shield-check';
+  import type { SubmitFunction } from '@sveltejs/kit';
+  import User from '@lucide/svelte/icons/user';
 
   import { cn } from '$util/cn';
   import { servicesList } from '$data/services';

--- a/src/components/content/services.svelte
+++ b/src/components/content/services.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { Compass, Workflow } from '@lucide/svelte';
+  import Compass from '@lucide/svelte/icons/compass';
+  import Workflow from '@lucide/svelte/icons/workflow';
 
   import { carousels } from '$store/services';
   import { t, locale } from '$i18n/config';

--- a/src/components/header/button-cta.svelte
+++ b/src/components/header/button-cta.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Mail } from '@lucide/svelte';
+  import Mail from '@lucide/svelte/icons/mail';
 
   import { t } from '$i18n/config';
   import Button from '$comp/button.svelte';

--- a/src/components/hero/browser.svelte
+++ b/src/components/hero/browser.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
-  import { ChevronDown, Lock, MessageCircleMore, RotateCw } from '@lucide/svelte';
+  import ChevronDown from '@lucide/svelte/icons/chevron-down';
+  import Lock from '@lucide/svelte/icons/lock';
+  import MessageCircleMore from '@lucide/svelte/icons/message-circle-more';
+  import RotateCw from '@lucide/svelte/icons/rotate-cw';
 
   import { t } from '$i18n/config';
   import Button from '$comp/button.svelte';

--- a/src/components/input-tel.svelte
+++ b/src/components/input-tel.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { Icon as IconType } from '@lucide/svelte';
-  import { ChevronsUpDown } from '@lucide/svelte';
+  import ChevronsUpDown from '@lucide/svelte/icons/chevrons-up-down';
   import { TelInput, normalizedCountries } from 'svelte-tel-input';
   import type {
     DetailedValue,

--- a/src/components/section/service.svelte
+++ b/src/components/section/service.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { CircleCheck, Sparkle } from '@lucide/svelte';
+  import CircleCheck from '@lucide/svelte/icons/circle-check';
+  import Sparkle from '@lucide/svelte/icons/sparkle';
 
   import { cn } from '$util/cn';
   import { formatCurrency } from '$util/format-currency';

--- a/src/components/section/testimonial.svelte
+++ b/src/components/section/testimonial.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Quote } from '@lucide/svelte';
+  import Quote from '@lucide/svelte/icons/quote';
 
   export let name: string | undefined;
   export let business: string | undefined;

--- a/src/components/select.svelte
+++ b/src/components/select.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { ChevronsUpDown, type Icon as IconType } from '@lucide/svelte';
+  import ChevronsUpDown from '@lucide/svelte/icons/chevrons-up-down';
+  import { type Icon as IconType } from '@lucide/svelte';
 
   import { cn } from '$util/cn';
 

--- a/src/components/switch-theme.svelte
+++ b/src/components/switch-theme.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-  import { Moon, Sun } from '@lucide/svelte';
   import { page } from '$app/state';
+  import Moon from '@lucide/svelte/icons/moon';
+  import Sun from '@lucide/svelte/icons/sun';
 
   import { t } from '$i18n/config';
   import { setTheme } from '$util/theme';

--- a/src/data/benefits.ts
+++ b/src/data/benefits.ts
@@ -1,14 +1,12 @@
-import {
-  Eye,
-  LifeBuoy,
-  Mail,
-  MessagesSquare,
-  Palette,
-  Rocket,
-  ShieldCheck,
-  TabletSmartphone,
-  Wrench
-} from '@lucide/svelte';
+import Eye from '@lucide/svelte/icons/eye';
+import LifeBuoy from '@lucide/svelte/icons/life-buoy';
+import Mail from '@lucide/svelte/icons/mail';
+import MessagesSquare from '@lucide/svelte/icons/messages-square';
+import Palette from '@lucide/svelte/icons/palette';
+import Rocket from '@lucide/svelte/icons/rocket';
+import ShieldCheck from '@lucide/svelte/icons/shield-check';
+import TabletSmartphone from '@lucide/svelte/icons/tablet-smartphone';
+import Wrench from '@lucide/svelte/icons/wrench';
 
 const benefits = {
   en: [

--- a/src/data/faq.ts
+++ b/src/data/faq.ts
@@ -1,4 +1,9 @@
-import { CircleHelp, Clock, DollarSign, Send, SquarePen, Star } from '@lucide/svelte';
+import CircleHelp from '@lucide/svelte/icons/circle-help';
+import Clock from '@lucide/svelte/icons/clock';
+import DollarSign from '@lucide/svelte/icons/dollar-sign';
+import Send from '@lucide/svelte/icons/send';
+import SquarePen from '@lucide/svelte/icons/square-pen';
+import Star from '@lucide/svelte/icons/star';
 
 const faq = {
   en: [

--- a/src/data/services.ts
+++ b/src/data/services.ts
@@ -1,15 +1,13 @@
-import {
-  BotMessageSquare,
-  CalendarCheck,
-  CircleEllipsis,
-  ClipboardList,
-  Eye,
-  FileText,
-  Hammer,
-  HelpCircle,
-  Speech,
-  Wrench
-} from '@lucide/svelte';
+import BotMessageSquare from '@lucide/svelte/icons/bot-message-square';
+import CalendarCheck from '@lucide/svelte/icons/calendar-check';
+import CircleEllipsis from '@lucide/svelte/icons/circle-ellipsis';
+import ClipboardList from '@lucide/svelte/icons/clipboard-list';
+import Eye from '@lucide/svelte/icons/eye';
+import FileText from '@lucide/svelte/icons/file-text';
+import Hammer from '@lucide/svelte/icons/hammer';
+import HelpCircle from '@lucide/svelte/icons/help-circle';
+import Speech from '@lucide/svelte/icons/speech';
+import Wrench from '@lucide/svelte/icons/wrench';
 
 const services = {
   en: [


### PR DESCRIPTION
This pull request refactors the import paths for Lucide icons across the project to use specific icon paths instead of the general `@lucide/svelte` package. This change improves tree-shaking and reduces the bundle size by ensuring only the required icons are included in the final build.

### Icon Import Refactoring:

* Updated all Lucide icon imports in `src/components` files to use specific paths (e.g., `@lucide/svelte/icons/[icon-name]`) instead of importing from the general `@lucide/svelte` package. This change affects components such as `accordion.svelte`, `carousel.svelte`, `contact.svelte`, `services.svelte`, and others. [[1]](diffhunk://#diff-838ca9be952eb37128730c60fe4e6d223889668362b46faab7c7728bf7d196b4L2-R3) [[2]](diffhunk://#diff-9f3f0798ba327963b54235dfe2c5f65e9e0a6b2cca89f3e28bd2386ef665b1cdL2-R5) [[3]](diffhunk://#diff-8042ac2d9cf763e94dea6e33cb98b68d426a71f47507c51b393cd9d449948142L2-R13) [[4]](diffhunk://#diff-a7f03ba4d8f8aeefbe4d054a002eafb3b3d6500f00320c02383a88c6f61fb9c6L2-R3) [[5]](diffhunk://#diff-6ec04695b78e5fbabd58ebb99a91c3bb9bb28d72cca4dc7eb66a47691d084137L2-R2) [[6]](diffhunk://#diff-151c9b6a68e573506cc90ca452423bac9d8617a0e5c06387fafb9836ea3b6642L2-R5) [[7]](diffhunk://#diff-23bd22d040e5051a72b9302fd3d6ed5c74e17c7a71ab4fecf03d4d34abbddd48L3-R3) [[8]](diffhunk://#diff-95f3c908a7c1d0ecb2f7d7a8b09c363fd5f509bf94b9696925ae04c6beba0193L2-R3) [[9]](diffhunk://#diff-354134e7348bcc4d045a05e957474b9acfe79c04e5a085e88d7fff6adddd031dL2-R2) [[10]](diffhunk://#diff-9c44f940602a70b0e7726f6733cf85966d3c4b9540971d52c1af9af7d03f6ec7L2-R3) [[11]](diffhunk://#diff-f88f6df61003a78a847e15cc294fbb0f5f52d4aa755e6dac37aed4fd6885dbe9L2-R4)

* Updated Lucide icon imports in `src/data` files (`benefits.ts`, `faq.ts`, `services.ts`) to follow the same pattern of importing from specific icon paths. [[1]](diffhunk://#diff-bc30eba1176d1a32a242fe8a4b2d72a793184e09d915d75c9ba8752af1099273L1-R9) [[2]](diffhunk://#diff-22e0448a46ba7300a1ad864e03f6ca5be60ded89bb7bb28f70e570bf80cded7fL1-R6) [[3]](diffhunk://#diff-3c76f9e2341a421edd73d9a933153bcf2b473da0ddd9e5550d583737560f89f9L1-R10)…-shaking